### PR TITLE
fix: Make `list` default to all namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ hammertime get -i <UUID>
 # get just the state of 'mvm0' in 'ns0' *see below
 hammertime get -i <UUID> -s
 
-# get all mvms
+# get all mvms across all namespaces
 hammertime list
 
 # delete

--- a/main.go
+++ b/main.go
@@ -163,11 +163,11 @@ func main() {
 			},
 			{
 				Name:  "list",
-				Usage: "list all microvms in namespace",
+				Usage: "list all microvms across all namespaces",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
 						Name:        "namespace",
-						Value:       defaultMvmNamespace,
+						Value:       "",
 						Aliases:     []string{"ns"},
 						Usage:       "microvm namespace",
 						Destination: &mvmNamespace,
@@ -180,7 +180,7 @@ func main() {
 					}
 					defer conn.Close()
 
-					res, err := listMicrovms(v1alpha1.NewMicroVMClient(conn), mvmName, mvmNamespace)
+					res, err := listMicrovms(v1alpha1.NewMicroVMClient(conn), "", mvmNamespace)
 					if err != nil {
 						return err
 					}


### PR DESCRIPTION
It is more useful to have it list everything unless told otherwise. Also
the `name` flag is not being used so there is no need to pass in the
`mvmName` variable.

List will be tested and bumped to use a new version of flintlock later.

This change does not break any open PRs.