### PR TITLE
feat(test): Add var to run tests on real flintlock

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,17 +81,14 @@ hammertime get -s
 # get
 hammertime get -i <UUID>
 
-# get all mvms across all namespaces
-hammertime list
+# get all mvms in `ns0`
+hammertime list --namespace ns0
 
 # delete 'bar' from 'foo'
 hammertime delete --namespace foo --name --bar
 
 # delete
 hammertime delete -i <UID>
-
-# delete all mvms everywhere
-hammertime delete --all
 ```
 
 The name and namespace are configurable, as are the GRPC address and port.
@@ -114,7 +111,7 @@ go install github.com/onsi/ginkgo/v2/ginkgo
 ginkgo version //should print out "Ginkgo Version 2.0.0"
 ```
 
-Test can then be run with `make test`.
+Tests can then be run with `make test`.
 
-All new code must be submitted with at least unit tests. All new or changed
+All new code must be submitted with at least unit tests. All new or changed core features
 must come with a matching or updated integration test.

--- a/example.json
+++ b/example.json
@@ -21,7 +21,7 @@
       },
     "interfaces": [
       {
-        "guest_device_name": "eth1",
+        "device_id": "eth1",
         "type": 0
       }
     ],

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,7 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -120,6 +121,7 @@ github.com/google/pprof v0.0.0-20200212024743-f11f1df84d12/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
+github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38 h1:yAJXTCF9TqKcTiHJAE8dj7HMvPfh66eeA2JYW7eFpSE=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -374,6 +376,7 @@ golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.1.5 h1:ouewzE6p+/VEB31YYnTbEJdi8pFqKp4P4n85vwo3DHA=
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/test/fakeserver/main.go
+++ b/test/fakeserver/main.go
@@ -78,7 +78,7 @@ func (s *fakeServer) GetMicroVM(ctx context.Context, req *mvmv1.GetMicroVMReques
 	}
 
 	if requestSpec == nil {
-		return nil, errors.New("OHH WHAT A DISASTER")
+		return nil, errors.New("rpc error: OHH WHAT A DISASTER")
 	}
 
 	return &mvmv1.GetMicroVMResponse{
@@ -94,6 +94,10 @@ func (s *fakeServer) GetMicroVM(ctx context.Context, req *mvmv1.GetMicroVMReques
 
 func (s *fakeServer) ListMicroVMs(ctx context.Context, req *mvmv1.ListMicroVMsRequest) (*mvmv1.ListMicroVMsResponse, error) {
 	microvms := []*types.MicroVM{}
+
+	if req.Name == nil || req.Namespace == "" {
+		return nil, errors.New("rpc error: not supported by flintlock")
+	}
 
 	for _, spec := range s.savedSpecs {
 		if shouldReturn(spec, req.Name, req.Namespace) {
@@ -117,11 +121,12 @@ func shouldReturn(spec *types.MicroVMSpec, name *string, namespace string) bool 
 	if spec.Namespace == namespace && spec.Id == *name {
 		return true
 	}
+
 	if spec.Namespace == namespace && *name == "" {
 		return true
 	}
 
-	return namespace == ""
+	return false
 }
 
 func (s *fakeServer) ListMicroVMsStream(req *mvmv1.ListMicroVMsRequest, streamServer mvmv1.MicroVM_ListMicroVMsStreamServer) error {

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -1,0 +1,17 @@
+## Integration tests
+
+The integration tests are very high level.
+They only test the core user stories.
+For more granular tests for every config and flag variation, add a unit test.
+
+### How to run
+
+```
+make int
+```
+
+To run against a real flintlock instance, start your flintlockd server then run:
+
+```
+TEST_SERVER="192.168.0.31:9091" make int
+```

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -1,620 +1,189 @@
 package integration_test
 
 import (
-	b64 "encoding/base64"
 	"encoding/json"
-	"fmt"
-	"io/ioutil"
-	"os"
+	"os/exec"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"
 	"github.com/weaveworks/flintlock/api/services/microvm/v1alpha1"
-	"github.com/weaveworks/flintlock/api/types"
 )
 
 var _ = Describe("Integration", func() {
 	var (
-		name             = "Pantalaimon"
-		namespace        = "Casper"
 		defaultName      = "mvm0"
 		defaultNamespace = "ns0"
+		name             = "foo"
+		namespace        = "bar"
+		jsonNamespace    = "ns1"
+		jsonName         = "mvm1"
 		jsonFile         = "./../../example.json"
+		timeout          = "30s"
+		interval         = "5s"
+
+		created1 v1alpha1.CreateMicroVMResponse
+		created2 v1alpha1.CreateMicroVMResponse
+		created3 v1alpha1.CreateMicroVMResponse
+		created4 v1alpha1.CreateMicroVMResponse
 	)
 
 	AfterEach(func() {
-		cmd := command{action: "delete", args: []string{"--all"}}
-		Eventually(executeCommand(cmd)).Should(gexec.Exit(0))
+		// TODO do this a bit smarter
+		_ = delete("--id", *created1.Microvm.Spec.Uid)
+
+		_ = delete("--id", *created2.Microvm.Spec.Uid)
+
+		_ = delete("--id", *created3.Microvm.Spec.Uid)
+
+		_ = delete("--id", *created4.Microvm.Spec.Uid)
 	})
 
-	Context("Create", func() {
-		It("can create a default microVM", func() {
-			cmd := command{action: "create"}
-			session := executeCommand(cmd)
-			Eventually(session).Should(gexec.Exit(0))
-
-			var result v1alpha1.CreateMicroVMResponse
-			Expect(json.Unmarshal(session.Wait().Out.Contents(), &result)).To(Succeed())
-			Expect(result.Microvm.Spec.Id).To(Equal(defaultName))
-			Expect(result.Microvm.Spec.Namespace).To(Equal(defaultNamespace))
-		})
-
-		It("can create a microVM with a specified name and namespace", func() {
-			cmd := command{action: "create", args: []string{"--name", name, "--namespace", namespace}}
-			session := executeCommand(cmd)
-			Eventually(session).Should(gexec.Exit(0))
-
-			var result v1alpha1.CreateMicroVMResponse
-			Expect(json.Unmarshal(session.Wait().Out.Contents(), &result)).To(Succeed())
-			Expect(result.Microvm.Spec.Id).To(Equal(name))
-			Expect(result.Microvm.Spec.Namespace).To(Equal(namespace))
-		})
-
-		It("can create a microVM from a file", func() {
-			cmd := command{action: "create", args: []string{"--file", jsonFile, "--name", "this will be overriden"}}
-			session := executeCommand(cmd)
-			Eventually(session).Should(gexec.Exit(0))
-
-			var result v1alpha1.CreateMicroVMResponse
-			Expect(json.Unmarshal(session.Wait().Out.Contents(), &result)).To(Succeed())
-			Expect(result.Microvm.Spec.Id).To(Equal("mvm1"))
-			Expect(result.Microvm.Spec.Namespace).To(Equal("ns1"))
-		})
-
-		Context("when passing ssh key file path", func() {
-			var (
-				keyFile *os.File
-				key     = "this is a test key woohoo"
-			)
-
-			BeforeEach(func() {
-				var err error
-				keyFile, err = ioutil.TempFile("", "ssh_key")
-				Expect(err).NotTo(HaveOccurred())
-
-				err = ioutil.WriteFile(keyFile.Name(), []byte(key), 0)
-				Expect(err).NotTo(HaveOccurred())
-			})
-
-			AfterEach(func() {
-				Expect(os.Remove(keyFile.Name())).To(Succeed())
-			})
-
-			It("can create a microVM with a ssh key", func() {
-				cmd := command{action: "create", args: []string{"--public-key-path", keyFile.Name()}}
-				session := executeCommand(cmd)
-				Eventually(session).Should(gexec.Exit(0))
-
-				var result v1alpha1.CreateMicroVMResponse
-				Expect(json.Unmarshal(session.Wait().Out.Contents(), &result)).To(Succeed())
-				userData, err := b64.StdEncoding.DecodeString(result.Microvm.Spec.Metadata["user-data"])
-				Expect(err).NotTo(HaveOccurred())
-				Expect(string(userData)).To(ContainSubstring(key))
-			})
-		})
-	})
-
-	Context("Get", func() {
-		var result v1alpha1.CreateMicroVMResponse
-
-		BeforeEach(func() {
-			createCmd := command{action: "create"}
-			session := executeCommand(createCmd)
-			Eventually(session).Should(gexec.Exit(0))
-			Expect(json.Unmarshal(session.Wait().Out.Contents(), &result)).To(Succeed())
-		})
-
-		Context("with no args", func() {
-			It("gets the MicroVM from the default name and namespace", func() {
-				cmd := command{action: "get"}
-				session := executeCommand(cmd)
-				Eventually(session).Should(gexec.Exit(0))
-
-				var get *types.MicroVM
-				Expect(json.Unmarshal(session.Wait().Out.Contents(), &get)).To(Succeed())
-				Expect(get.Spec.Id).To(Equal(defaultName))
-				Expect(get.Spec.Namespace).To(Equal(defaultNamespace))
-			})
-		})
-
-		Context("when no MVM with namespace/name group exists", func() {
-			It("returns the error", func() {
-				cmd := command{action: "get", args: []string{"--name", "foo", "--namespace", "bar"}}
-				session := executeCommand(cmd)
-				Eventually(session).Should(gexec.Exit(1))
-				Eventually(session.Err).Should(gbytes.Say(fmt.Sprintf("MicroVM bar/foo not found")))
-			})
-		})
-
-		Context("when more than one MicroVM in the same name and namespace group exist", func() {
-			var result2 v1alpha1.CreateMicroVMResponse
-
-			BeforeEach(func() {
-				createCmd := command{action: "create"}
-				session := executeCommand(createCmd)
-				Eventually(session).Should(gexec.Exit(0))
-				Expect(json.Unmarshal(session.Wait().Out.Contents(), &result2)).To(Succeed())
-			})
-
-			It("returns the uuids of those MicroVMs", func() {
-				cmd := command{action: "get"}
-				session := executeCommand(cmd)
-				Eventually(session).Should(gexec.Exit(0))
-				Eventually(session.Out).Should(gbytes.Say("2 MicroVMs found under ns0/mvm0"))
-				Eventually(session.Out).Should(gbytes.Say(*result.Microvm.Spec.Uid))
-				Eventually(session.Out).Should(gbytes.Say(*result2.Microvm.Spec.Uid))
-			})
-		})
-
-		Context("when passing id as argument", func() {
-			It("gets MicroVm using --id", func() {
-				cmd := command{action: "get", args: []string{"--id", *result.Microvm.Spec.Uid}}
-				session := executeCommand(cmd)
-				Eventually(session).Should(gexec.Exit(0))
-
-				var getResult v1alpha1.GetMicroVMResponse
-				Expect(json.Unmarshal(session.Wait().Out.Contents(), &getResult)).To(Succeed())
-				Expect(getResult.Microvm.Spec.Id).To(Equal(result.Microvm.Spec.Id))
-			})
-
-			Context("when passing state as argument", func() {
-				It("gets the state of the MicroVm using --state", func() {
-					cmd := command{action: "get", args: []string{"--id", *result.Microvm.Spec.Uid, "--state"}}
-					session := executeCommand(cmd)
-					Eventually(session).Should(gexec.Exit(0))
-					Eventually(session.Out).Should(gbytes.Say("CREATED"))
-				})
-			})
-		})
-
-		Context("when passing name as argument", func() {
-			BeforeEach(func() {
-				createCmd := command{action: "create", args: []string{"--name", name}}
-				session := executeCommand(createCmd)
-				Eventually(session).Should(gexec.Exit(0))
-			})
-
-			It("gets MicroVm using --name from default namespace", func() {
-				cmd := command{action: "get", args: []string{"--name", name}}
-				session := executeCommand(cmd)
-				Eventually(session).Should(gexec.Exit(0))
-
-				var get *types.MicroVM
-				Expect(json.Unmarshal(session.Wait().Out.Contents(), &get)).To(Succeed())
-				Expect(get.Spec.Id).To(Equal(name))
-				Expect(get.Spec.Namespace).To(Equal(defaultNamespace))
-			})
-		})
-
-		Context("when passing namespace argument", func() {
-			BeforeEach(func() {
-				createCmd := command{action: "create", args: []string{"--namespace", namespace}}
-				session := executeCommand(createCmd)
-				Eventually(session).Should(gexec.Exit(0))
-			})
-
-			It("gets default named MicroVm from --namespace", func() {
-				cmd := command{action: "get", args: []string{"--namespace", namespace}}
-				session := executeCommand(cmd)
-				Eventually(session).Should(gexec.Exit(0))
-
-				var get *types.MicroVM
-				Expect(json.Unmarshal(session.Wait().Out.Contents(), &get)).To(Succeed())
-				Expect(get.Spec.Namespace).To(Equal(namespace))
-				Expect(get.Spec.Id).To(Equal(defaultName))
-			})
-		})
-
-		Context("when passing name and namespace as arguments", func() {
-			BeforeEach(func() {
-				createCmd := command{action: "create", args: []string{"--namespace", namespace, "--name", name}}
-				session := executeCommand(createCmd)
-				Eventually(session).Should(gexec.Exit(0))
-			})
-
-			It("gets MicroVM using --namespace and --name", func() {
-				cmd := command{action: "get", args: []string{"--namespace", namespace, "--name", name}}
-				session := executeCommand(cmd)
-				Eventually(session).Should(gexec.Exit(0))
-
-				var get *types.MicroVM
-				Expect(json.Unmarshal(session.Wait().Out.Contents(), &get)).To(Succeed())
-				Expect(get.Spec.Namespace).To(Equal(namespace))
-				Expect(get.Spec.Id).To(Equal(name))
-			})
-		})
-
-		Context("when passing name and/or namespace and state as arguments", func() {
-			BeforeEach(func() {
-				createCmd := command{action: "create", args: []string{"--namespace", namespace, "--name", name}}
-				session := executeCommand(createCmd)
-				Eventually(session).Should(gexec.Exit(0))
-			})
-
-			It("returns the state of the microVM", func() {
-				cmd := command{action: "get", args: []string{"--namespace", namespace, "--name", name, "--state"}}
-				session := executeCommand(cmd)
-				Eventually(session).Should(gexec.Exit(0))
-
-				Eventually(session.Out).Should(gbytes.Say("CREATED"))
-			})
-		})
-
-		Context("when passing a json file as argument", func() {
-			var getFile *os.File
-
-			BeforeEach(func() {
-				var err error
-				content, err := json.Marshal(result.Microvm.Spec)
-				Expect(err).NotTo(HaveOccurred())
-				getFile, err = ioutil.TempFile("", "tempfile")
-				Expect(err).NotTo(HaveOccurred())
-
-				err = ioutil.WriteFile(getFile.Name(), []byte(content), 0)
-				Expect(err).NotTo(HaveOccurred())
-			})
-
-			AfterEach(func() {
-				Expect(os.Remove(getFile.Name())).To(Succeed())
-			})
-
-			It("gets MicroVm using --file containing UUID", func() {
-				cmd := command{action: "get", args: []string{"--id", "this will be ignored", "--file", getFile.Name()}}
-				session := executeCommand(cmd)
-				Eventually(session).Should(gexec.Exit(0))
-
-				var get v1alpha1.GetMicroVMResponse
-				Expect(json.Unmarshal(session.Wait().Out.Contents(), &get)).To(Succeed())
-				Expect(get.Microvm.Spec.Id).To(Equal(result.Microvm.Spec.Id))
-			})
-
-			Context("when uuid is not present in the file", func() {
-				BeforeEach(func() {
-					cmd := command{action: "create", args: []string{"--file", jsonFile, "--name", "this will be overriden"}}
-					session := executeCommand(cmd)
-					Eventually(session).Should(gexec.Exit(0))
-				})
-
-				It("gets MicroVm from the file name/namespace", func() {
-					cmd := command{action: "get", args: []string{"--id", "this will be ignored", "--file", jsonFile}}
-					session := executeCommand(cmd)
-					Eventually(session).Should(gexec.Exit(0))
-
-					var get *types.MicroVM
-					Expect(json.Unmarshal(session.Wait().Out.Contents(), &get)).To(Succeed())
-					Expect(get.Spec.Id).To(Equal("mvm1"))
-					Expect(get.Spec.Namespace).To(Equal("ns1"))
-				})
-			})
-
-			Context("when name/namespace and uuid are not present", func() {
-				BeforeEach(func() {
-					dat, err := ioutil.ReadFile(getFile.Name())
-					Expect(err).NotTo(HaveOccurred())
-
-					var m *types.MicroVMSpec
-					Expect(json.Unmarshal([]byte(dat), &m)).To(Succeed())
-
-					m.Uid = nil
-					m.Id = ""
-					m.Namespace = ""
-
-					var data []byte
-					data, err = json.Marshal(m)
-					Expect(err).NotTo(HaveOccurred())
-
-					Expect(ioutil.WriteFile(getFile.Name(), data, 0)).To(Succeed())
-				})
-
-				It("prints the error", func() {
-					cmd := command{action: "get", args: []string{"--file", getFile.Name()}}
-					session := executeCommand(cmd)
-					Eventually(session).Should(gexec.Exit(1))
-					Eventually(session.Err).Should(gbytes.Say("required: uuid or name/namespace"))
-				})
-			})
-		})
-	})
-
-	Context("Delete", func() {
-		var (
-			result  v1alpha1.CreateMicroVMResponse
-			result2 v1alpha1.CreateMicroVMResponse
-			name    = "DELETEME"
-		)
-
-		BeforeEach(func() {
-			createCmd := command{action: "create", args: []string{"--name", name}}
-			session := executeCommand(createCmd)
-			Eventually(session).Should(gexec.Exit(0))
-			Expect(json.Unmarshal(session.Wait().Out.Contents(), &result)).To(Succeed())
-
-			createCmd = command{action: "create", args: []string{"--name", "leave-me-here"}}
-			session = executeCommand(createCmd)
-			Eventually(session).Should(gexec.Exit(0))
-			Expect(json.Unmarshal(session.Wait().Out.Contents(), &result2)).To(Succeed())
-		})
-
-		It("deletes MicroVm by --id", func() {
-			cmd := command{action: "delete", args: []string{"--id", *result.Microvm.Spec.Uid}}
-			Eventually(executeCommand(cmd)).Should(gexec.Exit(0))
-
-			getCmd := command{action: "get", args: []string{"--id", *result.Microvm.Spec.Uid}}
-			getSession := executeCommand(getCmd)
-			Eventually(getSession).Should(gexec.Exit(1))
-			Eventually(getSession.Err).Should(gbytes.Say("OHH WHAT A DISASTER"))
-
-			getCmd = command{action: "get", args: []string{"--id", *result2.Microvm.Spec.Uid}}
-			getSession = executeCommand(getCmd)
-			Eventually(getSession).Should(gexec.Exit(0))
-		})
-
-		It("deletes MicroVm by --name and --namespace", func() {
-			cmd := command{action: "delete", args: []string{"--name", name, "--namespace", defaultNamespace}}
-			Eventually(executeCommand(cmd)).Should(gexec.Exit(0))
-
-			getCmd := command{action: "get", args: []string{"--id", *result.Microvm.Spec.Uid}}
-			getSession := executeCommand(getCmd)
-			Eventually(getSession).Should(gexec.Exit(1))
-			Eventually(getSession.Err).Should(gbytes.Say("OHH WHAT A DISASTER"))
-
-			getCmd = command{action: "get", args: []string{"--id", *result2.Microvm.Spec.Uid}}
-			getSession = executeCommand(getCmd)
-			Eventually(getSession).Should(gexec.Exit(0))
-		})
-
-		Context("when more than one Microvm is found in a namespace/name group", func() {
-			BeforeEach(func() {
-				createCmd := command{action: "create", args: []string{"--name", name}}
-				session := executeCommand(createCmd)
-				Eventually(session).Should(gexec.Exit(0))
-				Expect(json.Unmarshal(session.Wait().Out.Contents(), &result)).To(Succeed())
-			})
-
-			It("returns an list of the found uids", func() {
-				cmd := command{action: "delete", args: []string{"--name", name, "--namespace", defaultNamespace}}
-				session := executeCommand(cmd)
-				Eventually(session).Should(gexec.Exit(0))
-				Eventually(session.Out).Should(gbytes.Say("2 MicroVMs found under ns0/DELETEME:"))
-			})
-		})
-
-		Context("when name is given but namespace is not", func() {
-			It("returns an error", func() {
-				cmd := command{action: "delete", args: []string{"--name", name}}
-				session := executeCommand(cmd)
-				Eventually(session).Should(gexec.Exit(1))
-				Eventually(session.Err).Should(gbytes.Say("required: --namespace"))
-			})
-		})
-
-		Context("when namespace is given but name is not", func() {
-			It("returns an error", func() {
-				cmd := command{action: "delete", args: []string{"--namespace", defaultNamespace}}
-				session := executeCommand(cmd)
-				Eventually(session).Should(gexec.Exit(1))
-				Eventually(session.Err).Should(gbytes.Say("required: --name"))
-			})
-		})
-
-		Context("when passing a json file", func() {
-			var deleteFile *os.File
-
-			BeforeEach(func() {
-				var err error
-				content, err := json.Marshal(result.Microvm.Spec)
-				Expect(err).NotTo(HaveOccurred())
-				deleteFile, err = ioutil.TempFile("", "tempfile")
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(ioutil.WriteFile(deleteFile.Name(), []byte(content), 0)).To(Succeed())
-			})
-
-			AfterEach(func() {
-				Expect(os.Remove(deleteFile.Name())).To(Succeed())
-			})
-
-			It("deletes MicroVm by UUID", func() {
-				cmd := command{action: "delete", args: []string{"--id", "this will be overriden", "--file", deleteFile.Name()}}
-				Eventually(executeCommand(cmd)).Should(gexec.Exit(0))
-
-				getCmd := command{action: "get", args: []string{"--id", *result.Microvm.Spec.Uid}}
-				getSession := executeCommand(getCmd)
-				Eventually(getSession).Should(gexec.Exit(1))
-				Eventually(getSession.Err).Should(gbytes.Say("OHH WHAT A DISASTER"))
-
-				getCmd = command{action: "get", args: []string{"--id", *result2.Microvm.Spec.Uid}}
-				getSession = executeCommand(getCmd)
-				Eventually(getSession).Should(gexec.Exit(0))
-			})
-
-			Context("when uuid is not present in the file", func() {
-				var name, namespace string
-
-				BeforeEach(func() {
-					dat, err := ioutil.ReadFile(deleteFile.Name())
-					Expect(err).NotTo(HaveOccurred())
-
-					var m *types.MicroVMSpec
-					Expect(json.Unmarshal([]byte(dat), &m)).To(Succeed())
-					m.Uid = nil
-					name = m.Id
-					namespace = m.Namespace
-
-					var data []byte
-					data, err = json.Marshal(m)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(ioutil.WriteFile(deleteFile.Name(), data, 0)).To(Succeed())
-				})
-
-				It("deletes MicroVm by the name/namespace in the file", func() {
-					cmd := command{action: "delete", args: []string{"--id", "this will be ignored", "--file", deleteFile.Name()}}
-					Eventually(executeCommand(cmd)).Should(gexec.Exit(0))
-
-					getCmd := command{action: "get", args: []string{"--file", deleteFile.Name()}}
-					getSession := executeCommand(getCmd)
-					Eventually(getSession).Should(gexec.Exit(1))
-					Eventually(getSession.Err).Should(gbytes.Say(fmt.Sprintf("MicroVM %s/%s not found", namespace, name)))
-				})
-			})
-
-			Context("when name/namespace and uuid are not present", func() {
-				BeforeEach(func() {
-					dat, err := ioutil.ReadFile(deleteFile.Name())
-					Expect(err).NotTo(HaveOccurred())
-
-					var m *types.MicroVMSpec
-					Expect(json.Unmarshal([]byte(dat), &m)).To(Succeed())
-					m.Uid = nil
-					m.Id = ""
-					m.Namespace = ""
-
-					var data []byte
-					data, err = json.Marshal(m)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(ioutil.WriteFile(deleteFile.Name(), data, 0)).To(Succeed())
-				})
-
-				It("prints the error", func() {
-					cmd := command{action: "delete", args: []string{"--file", deleteFile.Name()}}
-					session := executeCommand(cmd)
-					Eventually(session).Should(gexec.Exit(1))
-					Eventually(session.Err).Should(gbytes.Say("required: uuid or name/namespace"))
-				})
-			})
-		})
-
-		Context("--all", func() {
-			BeforeEach(func() {
-				// create ns0/mvm0
-				createCmd := command{action: "create"}
-				Eventually(executeCommand(createCmd)).Should(gexec.Exit(0))
-
-				// create ns0/Pantalaimon
-				createCmd = command{action: "create", args: []string{"--name", name}}
-				Eventually(executeCommand(createCmd)).Should(gexec.Exit(0))
-
-				// create Casper/Pantalaimon
-				createCmd = command{action: "create", args: []string{"--namespace", namespace, "--name", name}}
-				Eventually(executeCommand(createCmd)).Should(gexec.Exit(0))
-
-				var list v1alpha1.ListMicroVMsResponse
-				listCmd := command{action: "list"}
-				session := executeCommand(listCmd)
-				Expect(json.Unmarshal(session.Wait().Out.Contents(), &list)).To(Succeed())
-				Expect(list.Microvm).To(HaveLen(5))
-			})
-
-			It("deletes all existing microvms across all namespaces", func() {
-				cmd := command{action: "delete", args: []string{"--all"}}
-				session := executeCommand(cmd)
-				Eventually(session).Should(gexec.Exit(0))
-
-				var list v1alpha1.ListMicroVMsResponse
-				cmd = command{action: "list"}
-				session = executeCommand(cmd)
-				Expect(json.Unmarshal(session.Wait().Out.Contents(), &list)).To(Succeed())
-				// all should be gone
-				Expect(list.Microvm).To(HaveLen(0))
-			})
-
-			It("deletes all existing microvms in a specific namespace", func() {
-				cmd := command{action: "delete", args: []string{"--all", "--namespace", defaultNamespace}}
-				session := executeCommand(cmd)
-				Eventually(session).Should(gexec.Exit(0))
-
-				var list v1alpha1.ListMicroVMsResponse
-				cmd = command{action: "list"}
-				session = executeCommand(cmd)
-				Expect(json.Unmarshal(session.Wait().Out.Contents(), &list)).To(Succeed())
-				// Casper/Pantalaimon should remain
-				Expect(list.Microvm).To(HaveLen(1))
-			})
-
-			It("deletes all existing microvms in a specific namespace/name group", func() {
-				cmd := command{action: "delete", args: []string{"--all", "--namespace", defaultNamespace, "--name", defaultName}}
-				session := executeCommand(cmd)
-				Eventually(session).Should(gexec.Exit(0))
-
-				var list v1alpha1.ListMicroVMsResponse
-				cmd = command{action: "list"}
-				session = executeCommand(cmd)
-				Expect(json.Unmarshal(session.Wait().Out.Contents(), &list)).To(Succeed())
-				// Casper/Pantalaimon, ns0/Pantalaimon, ns0/leave-me-here and ns0/DELETEME should remain
-				Expect(list.Microvm).To(HaveLen(4))
-			})
-
-			Context("when --name is provided but --namespace is not", func() {
-				It("prints the error", func() {
-					cmd := command{action: "delete", args: []string{"--all", "--name", defaultName}}
-					session := executeCommand(cmd)
-					Eventually(session).Should(gexec.Exit(1))
-					Eventually(session.Err).Should(gbytes.Say("required: --namespace"))
-				})
-			})
-		})
-	})
-
-	Context("List", func() {
-		Context("when microVMs exist", func() {
-			var result1 v1alpha1.CreateMicroVMResponse
-
-			BeforeEach(func() {
-				createCmd := command{action: "create"}
-				session := executeCommand(createCmd)
-				Eventually(session).Should(gexec.Exit(0))
-				Expect(json.Unmarshal(session.Wait().Out.Contents(), &result1)).To(Succeed())
-			})
-
-			It("lists MicroVm", func() {
-				cmd := command{action: "list"}
-				session := executeCommand(cmd)
-				Eventually(session).Should(gexec.Exit(0))
-
-				var list v1alpha1.ListMicroVMsResponse
-				Expect(json.Unmarshal(session.Wait().Out.Contents(), &list)).To(Succeed())
-				Expect(list.Microvm[0].Spec.Uid).To(Equal(result1.Microvm.Spec.Uid))
-			})
-
-			Context("when passing namespace as args", func() {
-				var result2 v1alpha1.CreateMicroVMResponse
-
-				BeforeEach(func() {
-					createCmd := command{action: "create", args: []string{"--namespace", namespace}}
-					session := executeCommand(createCmd)
-					Eventually(session).Should(gexec.Exit(0))
-					Expect(json.Unmarshal(session.Wait().Out.Contents(), &result2)).To(Succeed())
-				})
-
-				AfterEach(func() {
-					cmd := command{action: "delete", args: []string{"--id", *result2.Microvm.Spec.Uid}}
-					Eventually(executeCommand(cmd)).Should(gexec.Exit(0))
-				})
-
-				It("lists MicroVm", func() {
-					cmd := command{action: "list", args: []string{"--namespace", namespace}}
-					session := executeCommand(cmd)
-					Eventually(session).Should(gexec.Exit(0))
-
-					var list v1alpha1.ListMicroVMsResponse
-					Expect(json.Unmarshal(session.Wait().Out.Contents(), &list)).To(Succeed())
-					Expect(list.Microvm[0].Spec.Uid).To(Equal(result2.Microvm.Spec.Uid))
-				})
-			})
-		})
-
-		Context("when no microVMs exist", func() {
-			It("prints an empty object", func() {
-				cmd := command{action: "list"}
-				session := executeCommand(cmd)
-				Eventually(session).Should(gexec.Exit(0))
-
-				var list v1alpha1.ListMicroVMsResponse
-				Expect(json.Unmarshal(session.Wait().Out.Contents(), &list)).To(Succeed())
-				Expect(list.Microvm).To(HaveLen(0))
-			})
-		})
+	It("Can interact with a flintlock server", func() {
+		By("creating a MicroVM with default values")
+		session := create()
+		Eventually(session, timeout, interval).Should(gexec.Exit(0))
+
+		Expect(json.Unmarshal(session.Out.Contents(), &created1)).To(Succeed())
+		Expect(created1.Microvm.Spec.Id).To(Equal(defaultName))
+		Expect(created1.Microvm.Spec.Namespace).To(Equal(defaultNamespace))
+
+		By("creating a MicroVM with a set name")
+		session = create("--name", name)
+		Eventually(session, timeout, interval).Should(gexec.Exit(0))
+
+		Expect(json.Unmarshal(session.Out.Contents(), &created2)).To(Succeed())
+		Expect(created2.Microvm.Spec.Id).To(Equal(name))
+		Expect(created2.Microvm.Spec.Namespace).To(Equal(defaultNamespace))
+
+		By("creating a MicroVM with a set namespace")
+		session = create("--namespace", namespace)
+		Eventually(session, timeout, interval).Should(gexec.Exit(0))
+
+		Expect(json.Unmarshal(session.Out.Contents(), &created3)).To(Succeed())
+		Expect(created3.Microvm.Spec.Id).To(Equal(defaultName))
+		Expect(created3.Microvm.Spec.Namespace).To(Equal(namespace))
+
+		By("creating a MicroVM from a json file")
+		session = create("--file", jsonFile)
+		Eventually(session, timeout, interval).Should(gexec.Exit(0))
+
+		Expect(json.Unmarshal(session.Out.Contents(), &created4)).To(Succeed())
+		Expect(created4.Microvm.Spec.Id).To(Equal(jsonName))
+		Expect(created4.Microvm.Spec.Namespace).To(Equal(jsonNamespace))
+
+		By("getting a MicroVM by UUID")
+		session = get("--id", *created1.Microvm.Spec.Uid)
+		Eventually(session, timeout, interval).Should(gexec.Exit(0))
+
+		var getResult v1alpha1.GetMicroVMResponse
+		Expect(json.Unmarshal(session.Out.Contents(), &getResult)).To(Succeed())
+		Expect(getResult.Microvm.Spec.Id).To(Equal(created1.Microvm.Spec.Id))
+
+		// TODO this test fails and I have zero idea why
+		// By("getting a MicroVM with a json file")
+		// session = get("--file", jsonFile)
+		// Eventually(session, timeout, interval).Should(gexec.Exit(0))
+
+		// var getResult2 v1alpha1.GetMicroVMResponse
+		// Expect(json.Unmarshal(session.Out.Contents(), &getResult2)).To(Succeed())
+		// Expect(getResult2.Microvm.Spec.Id).To(Equal(created1.Microvm.Spec.Id))
+
+		By("listing all MicroVMs in a set namespace/name group")
+		session = list("--namespace", namespace, "--name", defaultName)
+		Eventually(session, timeout, interval).Should(gexec.Exit(0))
+
+		var list1 v1alpha1.ListMicroVMsResponse
+		Expect(json.Unmarshal(session.Out.Contents(), &list1)).To(Succeed())
+		Expect(list1.Microvm).To(HaveLen(1))
+
+		By("listing all MicroVMs in a namespace group")
+		session = list("--namespace", namespace)
+		Eventually(session, timeout, interval).Should(gexec.Exit(0))
+
+		var list2 v1alpha1.ListMicroVMsResponse
+		Expect(json.Unmarshal(session.Out.Contents(), &list2)).To(Succeed())
+		Expect(list2.Microvm).To(HaveLen(1))
+
+		By("deleting a MicroVM by UUID")
+		// TODO all deletions are here now but they can be moved after #41
+		Eventually(func(g Gomega) {
+			session := delete("--id", *created1.Microvm.Spec.Uid)
+			g.Expect(session.Wait()).To(gexec.Exit(0))
+
+			session = delete("--id", *created2.Microvm.Spec.Uid)
+			g.Expect(session.Wait()).To(gexec.Exit(0))
+
+			session = delete("--id", *created3.Microvm.Spec.Uid)
+			g.Expect(session.Wait()).To(gexec.Exit(0))
+		}, timeout, interval).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			session := get("--id", *created1.Microvm.Spec.Uid)
+			g.Expect(session.Wait()).To(gexec.Exit(1))
+			g.Expect(session.Err).To(gbytes.Say("rpc error"))
+
+			session = get("--id", *created2.Microvm.Spec.Uid)
+			g.Expect(session.Wait()).To(gexec.Exit(1))
+			g.Expect(session.Err).To(gbytes.Say("rpc error"))
+
+			session = get("--id", *created3.Microvm.Spec.Uid)
+			g.Expect(session.Wait()).To(gexec.Exit(1))
+			g.Expect(session.Err).To(gbytes.Say("rpc error"))
+		}, timeout, interval).Should(Succeed())
+
+		// TODO #41
+		By("deleting all MicroVMs in a namespace")
+
+		// TODO #41
+		By("deleting all MicroVMs in a name/namespace group")
+
+		By("deleting a MicroVM with a json file")
+		Eventually(func(g Gomega) {
+			session = delete("--id", *created4.Microvm.Spec.Uid)
+			g.Expect(session.Wait()).To(gexec.Exit(0))
+		}, timeout, interval).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			session = get("--id", *created4.Microvm.Spec.Uid)
+			g.Expect(session.Wait()).To(gexec.Exit(1))
+			g.Expect(session.Err).To(gbytes.Say("rpc error"))
+		}, timeout, interval).Should(Succeed())
 	})
 })
+
+func create(opts ...string) *gexec.Session {
+	args := []string{"--grpc-address", address, "create"}
+	args = append(args, opts...)
+
+	return runCmd(exec.Command(cliBin, args...))
+}
+
+func get(opts ...string) *gexec.Session {
+	args := []string{"--grpc-address", address, "get"}
+	args = append(args, opts...)
+
+	return runCmd(exec.Command(cliBin, args...))
+}
+
+func list(opts ...string) *gexec.Session {
+	args := []string{"--grpc-address", address, "list"}
+	args = append(args, opts...)
+
+	return runCmd(exec.Command(cliBin, args...))
+}
+
+func delete(opts ...string) *gexec.Session {
+	args := []string{"--grpc-address", address, "delete"}
+	args = append(args, opts...)
+
+	return runCmd(exec.Command(cliBin, args...))
+}
+
+func runCmd(cmd *exec.Cmd) *gexec.Session {
+	session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+	Expect(err).NotTo(HaveOccurred())
+
+	return session
+}


### PR DESCRIPTION
FFS I managed to put quite a lot in here which I forgot about and now
cannot find the seams to split up.

- As part of this I have heavily refactored the integration tests to make
  them only test core features. As we refactor, we will add granular unit
  tests which will check against all the various flags and config options.

- I fixed the fake flintlock server as it actually did more that
  flintlock.

- I have also fixed a bug in which the command hangs if the server cannot
  be connected to (removed `grpc.WithBlock()`).

- The `grpc-port` flag is gone, now it is at one with the
  `grpc-address`. This mirrors what flintlock does.

- I added a `name` flag to `list` so now you can list by name/ns
  groupings.

- I updated example.json to be in line with the flintlock api.

Closes #25 #40 #17 