### PR TITLE
ref: Move Dial into a separate package

### DIFF
--- a/pkg/command/create.go
+++ b/pkg/command/create.go
@@ -3,11 +3,10 @@ package command
 import (
 	"github.com/urfave/cli/v2"
 	"github.com/weaveworks/flintlock/api/services/microvm/v1alpha1"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/warehouse-13/hammertime/pkg/client"
 	"github.com/warehouse-13/hammertime/pkg/config"
+	"github.com/warehouse-13/hammertime/pkg/dialler"
 	"github.com/warehouse-13/hammertime/pkg/flags"
 	"github.com/warehouse-13/hammertime/pkg/utils"
 )
@@ -33,10 +32,7 @@ func createCommand() *cli.Command {
 }
 
 func createFn(cfg *config.Config) error {
-	conn, err := grpc.Dial(
-		cfg.GRPCAddress,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	)
+	conn, err := dialler.New(cfg.GRPCAddress)
 	if err != nil {
 		return err
 	}

--- a/pkg/command/delete.go
+++ b/pkg/command/delete.go
@@ -5,11 +5,10 @@ import (
 
 	"github.com/urfave/cli/v2"
 	"github.com/weaveworks/flintlock/api/services/microvm/v1alpha1"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/warehouse-13/hammertime/pkg/client"
 	"github.com/warehouse-13/hammertime/pkg/config"
+	"github.com/warehouse-13/hammertime/pkg/dialler"
 	"github.com/warehouse-13/hammertime/pkg/flags"
 	"github.com/warehouse-13/hammertime/pkg/utils"
 )
@@ -36,10 +35,7 @@ func deleteCommand() *cli.Command {
 }
 
 func deleteFn(cfg *config.Config) error { //nolint: cyclop // we are refactoring this file
-	conn, err := grpc.Dial(
-		cfg.GRPCAddress,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	)
+	conn, err := dialler.New(cfg.GRPCAddress)
 	if err != nil {
 		return err
 	}

--- a/pkg/command/get.go
+++ b/pkg/command/get.go
@@ -5,11 +5,10 @@ import (
 
 	"github.com/urfave/cli/v2"
 	"github.com/weaveworks/flintlock/api/services/microvm/v1alpha1"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/warehouse-13/hammertime/pkg/client"
 	"github.com/warehouse-13/hammertime/pkg/config"
+	"github.com/warehouse-13/hammertime/pkg/dialler"
 	"github.com/warehouse-13/hammertime/pkg/flags"
 	"github.com/warehouse-13/hammertime/pkg/utils"
 )
@@ -36,10 +35,7 @@ func getCommand() *cli.Command {
 }
 
 func getFn(cfg *config.Config) error {
-	conn, err := grpc.Dial(
-		cfg.GRPCAddress,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	)
+	conn, err := dialler.New(cfg.GRPCAddress)
 	if err != nil {
 		return err
 	}

--- a/pkg/command/list.go
+++ b/pkg/command/list.go
@@ -3,11 +3,10 @@ package command
 import (
 	"github.com/urfave/cli/v2"
 	"github.com/weaveworks/flintlock/api/services/microvm/v1alpha1"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/warehouse-13/hammertime/pkg/client"
 	"github.com/warehouse-13/hammertime/pkg/config"
+	"github.com/warehouse-13/hammertime/pkg/dialler"
 	"github.com/warehouse-13/hammertime/pkg/flags"
 	"github.com/warehouse-13/hammertime/pkg/utils"
 )
@@ -31,10 +30,7 @@ func listCommand() *cli.Command {
 }
 
 func listFn(cfg *config.Config) error {
-	conn, err := grpc.Dial(
-		cfg.GRPCAddress,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	)
+	conn, err := dialler.New(cfg.GRPCAddress)
 	if err != nil {
 		return err
 	}

--- a/pkg/dialler/dialler.go
+++ b/pkg/dialler/dialler.go
@@ -1,0 +1,15 @@
+package dialler
+
+import (
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// New process the dial config and returns a grpc.ClientConn. The caller is
+// responsible for closing the connection.
+func New(address string) (*grpc.ClientConn, error) {
+	return grpc.Dial(
+		address,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+}


### PR DESCRIPTION
This is just some housekeeping before we add Basic Auth and TLS support.
Having the connection created in a single place elsewhere means we don't
have to repeat ourselves when it comes to adding credentials etc.